### PR TITLE
Add "EU" region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ composer require gam6itko/sparkpost-mailer
 
 ## configuration
 
-services.yaml
+### services.yaml
 ```yaml
 services:
     mailer.transport_factory.sparkpost:
@@ -20,12 +20,24 @@ services:
             - {name: mailer.transport_factory}
 ```
 
-.env
+### .env
+
+#### Default region
+
 ```dotenv
 MAILER_DSN=sparkpost+api://api_key@default
 ```
 ```dotenv
 MAILER_DSN=sparkpost+smtp://user:password@default:port
+```
+
+#### EU region
+
+```dotenv
+MAILER_DSN=sparkpost+api://api_key@default?region=eu
+```
+```dotenv
+MAILER_DSN=sparkpost+smtp://user:password@default:port?region=eu
 ```
 
 ## tests

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![Build Status](https://travis-ci.com/gam6itko/sparkpost-mailer.svg?branch=master)](https://travis-ci.com/gam6itko/sparkpost-mailer)
 [![Coverage Status](https://coveralls.io/repos/github/gam6itko/sparkpost-mailer/badge.svg?branch=master)](https://coveralls.io/github/gam6itko/sparkpost-mailer?branch=master)
 
-## install
+## Installation
 
 ```bash
 composer require gam6itko/sparkpost-mailer
 ```
 
-## configuration
+## Configuration
 
 ### services.yaml
 ```yaml
@@ -40,10 +40,10 @@ MAILER_DSN=sparkpost+api://api_key@default?region=eu
 MAILER_DSN=sparkpost+smtp://user:password@default:port?region=eu
 ```
 
-## tests
+## Tests
 
 ### Using sink server 
-[About sink server](https://www.sparkpost.com/docs/faq/using-sink-server/)
+[About sink server](https://support.sparkpost.com/docs/faq/using-sink-server)
 
 ```yaml
 services:
@@ -53,4 +53,4 @@ services:
 
 ## Also
 
-[Api transmissions](https://developers.sparkpost.com/api/transmissions/)
+[Sparkpost's "transmissions" API reference](https://developers.sparkpost.com/api/transmissions/)

--- a/src/Transport/SparkPostSmtpTransport.php
+++ b/src/Transport/SparkPostSmtpTransport.php
@@ -8,9 +8,12 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class SparkPostSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, int $port = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, string $password, int $port = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, ?string $region = null, string $host = 'default')
     {
-        parent::__construct('smtp.sparkpostmail.com', $port ?: 587, false, $dispatcher, $logger);
+        if ('default' === $host) {
+            $host = \sprintf('smtp%s.sparkpostmail.com', $region ? '.'.$region : '');
+        }
+        parent::__construct($host, $port ?: 587, false, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Transport/SparkPostTransportFactory.php
+++ b/src/Transport/SparkPostTransportFactory.php
@@ -14,15 +14,17 @@ class SparkPostTransportFactory extends AbstractTransportFactory
         $scheme = $dsn->getScheme();
         $user = $this->getUser($dsn);
         $port = $dsn->getPort();
+        $region = $dsn->getOption('region');
 
-        if ('sparkpost+api' === $scheme) {
-            return new SparkPostApiTransport($user, $this->client, $this->dispatcher, $this->logger);
-        }
+        switch (true) {
+            case 'sparkpost+api' === $scheme:
+                return new SparkPostApiTransport($user, $this->client, $this->dispatcher, $this->logger, $region, $dsn->getHost());
 
-        if (in_array($scheme, ['sparkpost', 'sparkpost+smtp', 'sparkpost+smtps'])) {
-            $password = $this->getPassword($dsn);
-
-            return new SparkPostSmtpTransport($user, $password, $port, $this->dispatcher, $this->logger);
+            case 'sparkpost' === $scheme:
+            case 'sparkpost+smtp' === $scheme:
+            case 'sparkpost+smtps' === $scheme:
+                $password = $this->getPassword($dsn);
+                return new SparkPostSmtpTransport($user, $password, $port, $this->dispatcher, $this->logger, $region, $dsn->getHost());
         }
 
         throw new UnsupportedSchemeException($dsn, 'sparkpost', $this->getSupportedSchemes());

--- a/tests/Transport/SparkPostApiTransportTest.php
+++ b/tests/Transport/SparkPostApiTransportTest.php
@@ -251,11 +251,14 @@ JSON;
         $transport->send($this->createDefaultMessage(), $this->createDefaultEnvelope());
     }
 
-    public function testToString()
+    /**
+     * @dataProvider dataToString
+     */
+    public function testToString(?string $region, ?string $host, string $endpoint)
     {
         $client = $this->createMock(HttpClientInterface::class);
-        $transport = new SparkPostApiTransport('api-key', $client);
-        self::assertSame('sparkpost+api://', (string) $transport);
+        $transport = new SparkPostApiTransport('api-key', $client, null, null, $region, $host);
+        self::assertSame('sparkpost+api://' . $endpoint, (string) $transport);
     }
 
     /**
@@ -323,6 +326,25 @@ JSON;
                 ],
             ],
             '[{"message":"error 0"},{"message":"error 1"}]',
+        ];
+    }
+
+    public function dataToString(): iterable
+    {
+        yield [
+            null, 'default', 'api.sparkpost.com',
+        ];
+
+        yield [
+            'eu', 'default', 'api.eu.sparkpost.com',
+        ];
+
+        yield [
+            'eu', 'example.com', 'example.com',
+        ];
+
+        yield [
+            null, 'example.com', 'example.com',
         ];
     }
 }

--- a/tests/Transport/SparkPostSmtpTransportTest.php
+++ b/tests/Transport/SparkPostSmtpTransportTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Gam6itko\Symfony\Mailer\SparkPost\Test\Transport;
+
+use Gam6itko\Symfony\Mailer\SparkPost\Mime\ABTestEmail;
+use Gam6itko\Symfony\Mailer\SparkPost\Mime\SparkPostEmail;
+use Gam6itko\Symfony\Mailer\SparkPost\Mime\TemplateEmail;
+use Gam6itko\Symfony\Mailer\SparkPost\Transport\SparkPostApiTransport;
+use Gam6itko\Symfony\Mailer\SparkPost\Transport\SparkPostSmtpTransport;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\DelayedEnvelope;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @coversDefaultClass \Gam6itko\Symfony\Mailer\SparkPost\Transport\SparkPostApiTransport
+ */
+class SparkPostSmtpTransportTest extends TestCase
+{
+
+    /**
+     * @dataProvider dataToString
+     */
+    public function testToString(?string $region, ?string $host, ?int $port, string $endpoint)
+    {
+        $transport = new SparkPostSmtpTransport('username', 'password', $port, null, null, $region, $host);
+        self::assertSame('smtp://' . $endpoint, (string) $transport);
+    }
+
+    public function dataToString(): iterable
+    {
+        yield [
+            null, 'default', null, 'smtp.sparkpostmail.com:587',
+        ];
+
+        yield [
+            'eu', 'default', null, 'smtp.eu.sparkpostmail.com:587',
+        ];
+
+        yield [
+            'eu', 'example.com', null, 'example.com:587',
+        ];
+
+        yield [
+            null, 'example.com', null, 'example.com:587',
+        ];
+
+        yield [
+            null, 'default', 1111, 'smtp.sparkpostmail.com:1111',
+        ];
+
+        yield [
+            'eu', 'default', 1111, 'smtp.eu.sparkpostmail.com:1111',
+        ];
+
+        yield [
+            'eu', 'example.com', 1111, 'example.com:1111',
+        ];
+
+        yield [
+            null, 'example.com', 1111, 'example.com:1111',
+        ];
+    }
+}

--- a/tests/Transport/SparkPostTransportFactoryTest.php
+++ b/tests/Transport/SparkPostTransportFactoryTest.php
@@ -27,12 +27,27 @@ class SparkPostTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('sparkpost', 'example.com'),
+            true,
+        ];
+
+        yield [
             new Dsn('sparkpost+api', 'default'),
             true,
         ];
 
         yield [
+            new Dsn('sparkpost+api', 'example.com'),
+            true,
+        ];
+
+        yield [
             new Dsn('sparkpost+https', 'default'),
+            false,
+        ];
+
+        yield [
+            new Dsn('sparkpost+https', 'example.com'),
             false,
         ];
 
@@ -64,19 +79,46 @@ class SparkPostTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('sparkpost+api', 'default', self::USER, null, null, ['region' => 'eu']),
+            new SparkPostApiTransport(self::USER, $client, $dispatcher, $logger, 'eu'),
+        ];
+
+        yield [
+            new Dsn('sparkpost+api', 'example.com', self::USER),
+            new SparkPostApiTransport(self::USER, $client, $dispatcher, $logger, null, 'example.com'),
+        ];
+
+        yield [
+            new Dsn('sparkpost+api', 'example.com', self::USER, null, null, ['region' => 'eu']),
+            new SparkPostApiTransport(self::USER, $client, $dispatcher, $logger, 'eu', 'example.com'),
+        ];
+
+        yield [
             new Dsn('sparkpost', 'default', self::USER, self::PASSWORD),
             new SparkPostSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger),
         ];
 
-        yield [
-            new Dsn('sparkpost+smtp', 'default', self::USER, self::PASSWORD, 587),
-            new SparkPostSmtpTransport(self::USER, self::PASSWORD, 587, $dispatcher, $logger),
-        ];
+        foreach (['sparkpost', 'sparkpost+smtp', 'sparkpost+smtps'] as $scheme) {
+            yield [
+                new Dsn($scheme, 'default', self::USER, self::PASSWORD, null, ['region' => 'eu']),
+                new SparkPostSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger, 'eu'),
+            ];
 
-        yield [
-            new Dsn('sparkpost+smtps', 'default', self::USER, self::PASSWORD, 2525),
-            new SparkPostSmtpTransport(self::USER, self::PASSWORD, 2525, $dispatcher, $logger),
-        ];
+            yield [
+                new Dsn($scheme, 'example.com', self::USER, self::PASSWORD),
+                new SparkPostSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger, null, 'example.com'),
+            ];
+
+            yield [
+                new Dsn($scheme, 'example.com', self::USER, self::PASSWORD, null, ['region' => 'eu']),
+                new SparkPostSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger, 'eu', 'example.com'),
+            ];
+
+            yield [
+                new Dsn($scheme, 'example.com', self::USER, self::PASSWORD, 1111, ['region' => 'eu']),
+                new SparkPostSmtpTransport(self::USER, self::PASSWORD, 1111, $dispatcher, $logger, 'eu', 'example.com'),
+            ];
+        }
     }
 
     public function unsupportedSchemeProvider(): iterable


### PR DESCRIPTION
The main goal of this PR is to add support for the `eu` region, which is not usable today with the current library version.

**Notes:**

* added support to override the `host`;
* updated the documentation;
* added SMTP transport tests;
* added new API transport tests;
* the new version is fully backward-compatible with existing implementations --> it's safe for users to upgrade.

