### PR TITLE
Fix support of replyTo on Api Transport

### DIFF
--- a/src/Transport/SparkPostApiTransport.php
+++ b/src/Transport/SparkPostApiTransport.php
@@ -105,7 +105,9 @@ class SparkPostApiTransport extends AbstractApiTransport
             'subject'     => $email->getSubject(),
             'text'        => $email->getTextBody(),
             'html'        => $email->getHtmlBody(),
-            'replyTo'     => $email->getReplyTo(),
+            'reply_to'     => implode(',', array_map(function ($replyTo) {
+                return $replyTo->toString();
+            }, $email->getReplyTo())),
             'attachments' => $this->buildAttachments($email),
         ]);
     }

--- a/tests/Transport/SparkPostApiTransportTest.php
+++ b/tests/Transport/SparkPostApiTransportTest.php
@@ -108,6 +108,36 @@ JSON;
 
         $json = <<<JSON
 {
+    "recipients": [
+        {
+            "address": {
+                "email": "fabien@symfony.com"
+            }
+        }
+    ],
+    "content": {
+        "from": {
+            "email": "gam6itko@gmail.com"
+        },
+        "subject": "Test email",
+        "text": "Test email for you!",
+        "reply_to": "no-reply@mail.com,\"Gam6itko\" <gam6itko+no-reply@gmail.com>,no-reply2@mail.com,\"Fabien\" <fabien+no-reply@symfony.com>"
+    }
+}
+JSON;
+        yield [
+            (new Email())
+                ->from('sender@mail.com')
+                ->to('recipient@mail.com')
+                ->replyTo('no-reply@mail.com', new Address('gam6itko+no-reply@gmail.com', 'Gam6itko'), 'no-reply2@mail.com', new Address('fabien+no-reply@symfony.com', 'Fabien'))
+                ->subject('Test email')
+                ->text('Test email for you!'),
+            new Envelope(new Address('gam6itko@gmail.com'), [new Address('fabien@symfony.com')]),
+            $json,
+        ];
+
+        $json = <<<JSON
+{
   "options": {
     "click_tracking": false,
     "transactional": true,


### PR DESCRIPTION
Hi,

In the payload generated to be sent to the Sparkpost API the Reply-To is set with a camelCase key but [Sparkpost transmissions API](https://developers.sparkpost.com/api/transmissions/#transmissions-post-send-inline-content) indicate it as snake_case. Also, this field can contains multiple mail adresses but need to be a string.

Let me know if you want me to adapt the code or the tests in another way.

Cheers